### PR TITLE
Small update to documentation

### DIFF
--- a/docs/use/pro-1-x.md
+++ b/docs/use/pro-1-x.md
@@ -168,7 +168,7 @@ export default class LandingLayout extends React.Component {
 + const BasicLayout = routerData['/dashboards'].component;
 - const BasicLayout = routerData['/'].component;  
   ...
-+     <Route path="/" component={PageLayout} />
++     <Route exact path="/" component={PageLayout} />
       <Route path="/user" component={UserLayout} />
       <AuthorizedRoute
 +       path="/dashboards"


### PR DESCRIPTION
The only way I was able to get this to work was adding the 'exact' attribute to the landing/homepage. Otherwise, all other routes get overridden by the layout template assigned to the '/' route.